### PR TITLE
Translate Advanced Configuration

### DIFF
--- a/source/advanced/cache.rst
+++ b/source/advanced/cache.rst
@@ -1,30 +1,30 @@
-Utilisation du cache
+Using the cache
 --------------------
 
-Les informations sur l'utilisation du cache sont disponible dans Configuration / Générale / Système).
+Information on cache usage is available in Configuration / General / System).
 
 .. versionadded:: 9.2
 
 .. versionchanged:: 9.2.1
 
-Si l'un des systèmes de cache `APCu` ou `WinCache` est présent sur le serveur, il sera automatiquement utilisé par GLPI. Le système se base sur `ZendCache <https://zendframework.github.io/zend-cache/>`_
+If one of the APCu or WinCache cache systems is present on the server, it will be automatically used by GLPI. The system is based on Symfony Cache.
 
-Le cache permet d'améliorer les performances sur certaines opérations relativement lourdes, telles que le chargement des traductions, ou le calcul des arbres des entités.
+The cache makes it possible to improve performance on certain relatively heavy operations, such as loading translations, or calculating entity trees.
 
-On distingue deux caches distincts dans GLPI :
+There are two distinct caches in GLPI:
 
-* le cache base de données,
-* le cache traduction.
+* The database cache
+* The translations cache
 
-Cette distinction permet d'éviter de stocker le cache des traductions sur un réseau, cela pourrait produire un trop grand nombre de requêtes sur le réseau et avoir au final un impact négatif.
+This distinction makes it possible to avoid storing the translation cache on a network, which could produce too many requests on the network and ultimately have a negative impact.
 
-A l'inverse, le cache de la base de données devrait être sur le réseau en cas de frontaux multiples.
+Conversely, the database cache should be on the network in case of multiple front-ends.
 
-Afin de vous permettre d'affiner les réglages, ou d'utiliser un autre système de cache, une solution manuelle est proposée. Pour en profiter, ajouter dans la table ``glpi_configs`` une clé ``cache_db`` et/ou ``cache_trans`` pour le contexte ``core`` et adapter la valeur en fonction de ce que vous souhaitez.
+In order to allow you to refine the settings, or to use another cache system, a manual solution is proposed. To take advantage of it, add to the ``glpi_configs`` table a ``cache_db`` and/or ``cache_trans`` key for the ``core`` context and adapt the value according to what you want.
 
 .. note::
 
-   Si le but est de désactiver l'un ou l'autre de ces caches, créer la clé dans la table, mais laisser la valeur vide.
+   If the goal is to disable either of these caches, create the key in the table, but leave the value blank.
 
 .. code-block:: json
 
@@ -34,25 +34,23 @@ Afin de vous permettre d'affiner les réglages, ou d'utiliser un autre système 
 
    {"adapter":"redis","options":{"server":{"host":"127.0.0.1"}}}
 
-Se référer à la méthode `Config::getCache() <https://forge.glpi-project.org/apidoc/source-class-Config.html>`_ et à la `documentation de ZendCache <https://zendframework.github.io/zend-cache/storage/adapter/>`_ pour davantage d'informations.
+Refer to the `Config::getCache() <https://forge.glpi-project.org/apidoc/source-class-Config.html>`_ method and `Symfony Cache documentation <https://symfony.com/doc/current/components/cache.html>`_ for more information.
 
 .. warning::
 
-   Si vous installez plusieurs instances de GLPI sur un même serveur, le `namespace` du cache doit être unique par instance, ce qui n'était pas le cas dans GLPI avant la version 9.2.4.
+   If you install several instances of GLPI on the same server, the cache namespace must be unique per instance, which was not the case in GLPI before version 9.2.4.
 
-   Si vous avez spécifié votre propre `namespace` dans la configuration, assurez-vous qu'il est bien unique sur chaque instance !
+   If you have specified your own namespace in the configuration, make sure that it is unique on each instance!
 
-   Si votre version de GLPI est antérieure à la 9.2.4, il faudra ajouter le `namespace` dans la configuration du cache de chacune de vos instances.
+   If your version of GLPI is earlier than 9.2.4, you will need to add the namespace in the cache configuration of each of your instances.
 
 OPCache
 -------
 
-OPCache stocke des fichiers PHP pré-compilés en mémoire, et permet ainsi d'améliorer les performances. La seule chose à faire, c'est de l'installer sur votre instance de PHP et de le configurer (la configuration par défaut devrait convenir à la grande majorité des cas).
+OPCache stores pre-compiled PHP files in memory, which improves performance. The only thing to do is to install it on your PHP instance and configure it (the default configuration should be fine in the vast majority of cases).
 
-Toutefois, sur des instances qui pourraient être fortement sollicitées, il peut être utile de ne pas inclures les fichiers de polices pour les PDF dans ce cache. En effet, elles y prennent énormément de place, et le gain est relativement minime.
+However, on instances that could be heavily used, it may be useful not to include font files for PDFs in this cache. Indeed, they take up a lot of space, and the gain is relatively minimal.
 
-Afin d'exclure les fichiers de police du cache, il suffit de renseigner leur chemin complet dans un fichier de liste noire pour opcache. Le chemin de ce fichier est déterminé par la diective de configuration ``opcache.blacklist_filename`` (``/etc/php.d/opcache-glpi.blacklist`` par exemple sous Fedora). Si votre instance de GLPI se situe dans le dossier ``/var/www/``, le chemin à exclure sera ``/var/www/html/glpi/glpi-9.2.1/vendor/tecnickcom/tcpdf/fonts/``.
+In order to exclude the font files from the cache, all you have to do is enter their full path in a blacklist file for opcache. The path to this file is determined by the configuration diective ``opcache.blacklist_filename`` ( ``/etc/php.d/opcache-glpi.blacklist`` for example under Fedora). If your GLPI instance is in the folder ``/var/www/``, the path to exclude will be ``/var/www/html/glpi/glpi-9.2.1/vendor/tecnickcom/tcpdf/fonts/``.
 
-Bien entendu, l'emplacement du fichier de configuration et le chemin vers les polices est à adapter en fonction de votre système et de votre type d'installation.
-
-Les RPMS fournis pour Fedora (ou par le dépôt Remi) offrent déjà cette fonctionnalité par défaut, vous n'aurez donc rien à faire :)
+Of course, the location of the configuration file and the path to the fonts should be adapted according to your system and your type of installation.


### PR DESCRIPTION
Translate the last remaining page accessible from the menu that needed translating.

I replaced references to Zend Cache with Symfony Cache.