### PR TITLE
Document Native Inventory

### DIFF
--- a/source/modules/assets/index.rst
+++ b/source/modules/assets/index.rst
@@ -8,7 +8,13 @@ Asset management in GLPI
 
 In order to manage hardwares and software of an IT infrastructure, GLPI allows natively to list all the assets that are used inside the managed organization.
 
-However, it is possible to automate information pushing from the assets thanks to third-party tools. GLPI supports the use of two existing plugins:
+However, it is possible to automate information pushing from the assets thanks to the native inventory and GLPI Agent and third-party tools.
+
+More information on the GLPI Agent can be found in its dedicated `documentation <https://glpi-agent.readthedocs.io/en/latest/index.html>`_.
+
+If you have used Fusion Inventory in the past with GLPI, it is very easy to migrate over to the GLPI Agent due to the native inventory remaining compatible with the Fusion Inventory agent.
+
+GLPI also supports the use of two existing plugins:
 
 * The `Fusion Inventory <https://github.com/fusioninventory/fusioninventory-for-glpi/>`_ plugin transforms GLPI into an inventory server with the Fusion Inventory agents interfacing directly with the GLPI server.
 

--- a/source/modules/assets/index.rst
+++ b/source/modules/assets/index.rst
@@ -12,9 +12,9 @@ However, it is possible to automate information pushing from the assets thanks t
 
 More information on the GLPI Agent can be found in its dedicated `documentation <https://glpi-agent.readthedocs.io/en/latest/index.html>`_.
 
-If you have used Fusion Inventory in the past with GLPI, it is very easy to migrate over to the GLPI Agent due to the native inventory remaining compatible with the Fusion Inventory agent.
+.. note:: If you have used Fusion Inventory in the past with GLPI, it is very easy to migrate over to the GLPI Agent due to the native inventory remaining compatible with the Fusion Inventory agent.
 
-GLPI also supports the use of two existing plugins:
+GLPI also supports automatic inventory via multiple plugins including but not limited to:
 
 * The `Fusion Inventory <https://github.com/fusioninventory/fusioninventory-for-glpi/>`_ plugin transforms GLPI into an inventory server with the Fusion Inventory agents interfacing directly with the GLPI server.
 


### PR DESCRIPTION
I included a reference to the new native inventory and GLPI Agent in the Assets documentation above 3rd party plugin solutions.
The only thing I added besides the reference was a note that migration from Fusion Inventory to GLPI Agent would be easy. The rest of the information for the agent side can be gotten from the main GLPI Agent documentation.

I'm leaving this as WIP to get feedback on what should be covered for the GLPI side of this feature.