### PR TITLE
Document LDAP Restore Feature

### DIFF
--- a/source/modules/configuration/authentication/configuration.rst
+++ b/source/modules/configuration/authentication/configuration.rst
@@ -21,7 +21,7 @@ It is also at this level that the time zone of GLPI is set.
 External authentication sources that can be used inside GLPI are:
 
 *  :doc:`LDAP directories <ldap>`
-*  :doc:`emails servers <imap>`
+*  :doc:`Email servers <imap>`
 *  :ref:`CAS server <auth_cas>`
 *  :ref:`x509 certificate <auth_x509>`
-*  :ref:`delegate authentication to web server <auth_other>`
+*  :ref:`Delegate authentication to web server <auth_other>`

--- a/source/modules/configuration/authentication/configuration.rst
+++ b/source/modules/configuration/authentication/configuration.rst
@@ -11,7 +11,11 @@ To use the capacity of GLPI to create on the fly users present in the external s
    :alt: Authentication configuration menu
    :align: center
    
-The LDAP directories also allow you to refuse the creation of users who do not have authorizations. Deleting a user from the directory can also lead to an action such as trashing the user, deleting his permissions or deactivating him.
+The LDAP directories also allow you to refuse the creation of users who do not have authorizations.
+Deleting a user from the directory can also lead to an action such as trashing the user, deleting his permissions or deactivating him.
+You also have the option to specify how to handle users that were previously deleted from the directory but are now restored.
+You can set the restore action to do nothing, restore the user from the trashbin, or re-enable the user.
+
 It is also at this level that the time zone of GLPI is set.
 
 External authentication sources that can be used inside GLPI are:

--- a/source/modules/configuration/authentication/ldap.rst
+++ b/source/modules/configuration/authentication/ldap.rst
@@ -1,9 +1,9 @@
 LDAP directories
 ================
 
-GLPI can interface with one or more :term:`Annuaire LDAP <LDAP directory>`  in order to authenticate users, control their access, retrieve their personal information and import groups.
+GLPI can interface with one or more :term:`LDAP directories <LDAP directory>`  in order to authenticate users, control their access, retrieve their personal information and import groups.
 
-All the directories compatible LDAP v3 are supported by GLPI. It is thus also the case for the l':term:`Annuaire Active Directory <Active Directory service>` of Microsoft.
+All the directories compatible LDAP v3 are supported by GLPI. It is thus also the case for the ':term:`Active Directory <Active Directory service>` of Microsoft.
 There is no limit as to the number of directories informed. However, the higher the number, the longer the search for a new user to authenticate can be.
 
 It is possible to import and synchronize users in 2 ways:


### PR DESCRIPTION
Document ability to handle users in GLPI that were previously removed from an LDAP directory (or put into Active Directory recycle bin), but have since been restored.