### PR TITLE
FAQ articles cannot be restricted like other articles

### DIFF
--- a/source/modules/tools/knowledgebase.rst
+++ b/source/modules/tools/knowledgebase.rst
@@ -8,8 +8,9 @@ GLPI knowledge base has two main targets:
 
 .. note::
    Only public FAQ items are visible to users of simplified interface. Other elements are visible only to technicians via standard interface.
+   FAQ items are public to everyone (within their entity) that has access to read FAQs. The additional visibility restrictions will have no affect in this case.
 
-Each article of the knowledge base or of the FAQ must have one or several targets, a target being either an entity, a group, a profile or a user, to be readable. As long as an article has no target, it is visible only by its writer, is flagged as `unpublished` and appears in table `Unpublished articles` on the home page of the knowledge base.
+Each article of the knowledge base that is not in the FAQ must have one or several targets, a target being either an entity, a group, a profile or a user, to be readable. As long as an article has no target, it is visible only by its writer, is flagged as `unpublished` and appears in table `Unpublished articles` on the home page of the knowledge base.
 
 By default, articles are not translatable. However, this functionality can be activated, see :doc:`general configuration </modules/configuration/general/general_configuration>`.
 


### PR DESCRIPTION
The documentation says that all articles including those in the FAQ have to have a visibility target. This is not the case and doesn't seem to be the intended behavior. The visibility criteria in the code is if the article is in the public FAQ OR it meets the other criteria based on the visibility targets.

Ref glpi-project/glpi#10746